### PR TITLE
Add the "kubeconfig_filename" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This plugin allows for creation and configuration of a KinD cluster within a Bui
 
 # Options
 
-* k8s_version: The major and minor release of K8S that you would like to target (i.e. v1.29, v1.28, etc.). Default (`v1.29`)
-* custom_image: The repository location of a KinD node image that you would like to use rather than the standard published versions from the KinD project (ex: quay.io/myorg/mynodeimage:v1.0.0). This will take priority over `k8s_version`.
-* kind_version: The version of the KinD binary you would like to use. Defaults to `v0.21.0`.
-* helm_version: The version of the Helm binary you would like to install. Defaults to `v3.14.0`.
-* config_path: A path within your codebase that contains a KinD configuration file.
-* debug_plugin: Whether to add verbosity to the logging of the plugin itself. This sets the `-x` flag within the plugin to show what commands are being run.
+* `k8s_version`: The major and minor release of K8S that you would like to target (i.e. 1.29, 1.28, etc.). Defaults to `1.29`.
+* `custom_image`: The repository location of a KinD node image that you would like to use rather than the standard published versions from the KinD project (e.g., `quay.io/myorg/mynodeimage:v1.0.0`). This will take priority over `k8s_version`.
+* `kind_version`: The version of the KinD binary you would like to use. Defaults to `v0.27.0`.
+* `helm_version`: The version of the Helm binary you would like to install. Defaults to `v3.17.1`.
+* `config_path`: A path within your codebase that contains a KinD configuration file.
+* `debug_plugin`: Whether to add verbosity to the logging of the plugin itself. This sets the `-x` flag within the plugin to show what commands are being run.
 
 # Usage
 
@@ -24,3 +24,23 @@ steps:
 ```
 
 **Note:** It's important that the k8s_version is in quotes so that it is evaluated appropriately.
+
+You can combine this plugin with the docker plugin by sharing the Kubeconfig file between the two:
+
+```sh
+steps:
+  - label: ":k8s: Get Pods"
+    plugins:
+      - ssh://git@github.com/equinixmetal-buildkite/kind-cluster-buildkite-plugin#main:
+          k8s_version: "1.29"
+          kubeconfig_filename: "kubeconfig-kind-cluster"
+      - docker#v5.12.0:
+          image: "bitnami/kubectl:latest"
+          network: host
+          volumes:
+            - "./kubeconfig-kind-cluster:/.kube/config"
+
+          # with the following command we run "kubectl get nodes" from inside the Bitnami Kubectl container
+          # against the KinD cluster
+          command: ["get", "nodes"]
+```

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -34,5 +34,6 @@ echo "--- :k8s: Setting Kubeconfig"
 KUBECONFIG_FILENAME=${BUILDKITE_PLUGIN_KIND_CLUSTER_KUBECONFIG_FILENAME:-kubeconfig-${CLUSTER_NAME}}
 export KUBECONFIG=$(pwd)/${KUBECONFIG_FILENAME}
 kind export kubeconfig --name ${CLUSTER_NAME} --kubeconfig ${KUBECONFIG}
+chmod 644 ${KUBECONFIG}
 echo "Saved the kubeconfig to ${KUBECONFIG}"
-
+stat ${KUBECONFIG}

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -31,7 +31,8 @@ echo "--- :k8s: Creating Cluster - ${CLUSTER_NAME}"
 kind create cluster --name ${CLUSTER_NAME} --image ${IMAGE} ${KIND_CONFIG:-} --wait 2m
 
 echo "--- :k8s: Setting Kubeconfig"
-kind export kubeconfig --name ${CLUSTER_NAME} --kubeconfig ./kubeconfig-${CLUSTER_NAME}
-echo "Saved the kubeconfig to $(pwd)/kubeconfig-${CLUSTER_NAME}"
-export KUBECONFIG=$(pwd)/kubeconfig-${CLUSTER_NAME}
+KUBECONFIG_FILENAME=${BUILDKITE_PLUGIN_KIND_CLUSTER_KUBECONFIG_FILENAME:-kubeconfig-${CLUSTER_NAME}}
+export KUBECONFIG=$(pwd)/${KUBECONFIG_FILENAME}
+kind export kubeconfig --name ${CLUSTER_NAME} --kubeconfig ${KUBECONFIG}
+echo "Saved the kubeconfig to ${KUBECONFIG}"
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,6 +14,8 @@ configuration:
       type: string
     config_path:
       type: string
+    kubeconfig_filename:
+      type: string
     debug_plugin:
       type: string
 additionalProperties: false


### PR DESCRIPTION
This PR is adding a new option kubeconfig_filename that allows to easily share the kubeconfig across Buildkite steps